### PR TITLE
fix glob-source to return paths good for require()

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "glob-promise": "^1.0.4",
     "lodash.assign": "^3.2.0",
     "q": "^1.4.1",
+    "require-path-relative": "^1.0.1",
     "webpack": "^1.12.9"
   }
 }

--- a/source/glob-source.js
+++ b/source/glob-source.js
@@ -10,7 +10,7 @@
  */
 function globSource(pattern, options) {
   return function list(outputPath) {
-    var path = require('path');
+    var relative = require('require-path-relative');
 
     var ModuleFilenameHelpers = require('webpack/lib/ModuleFilenameHelpers'),
         glob                  = require('glob-promise');
@@ -29,7 +29,7 @@ function globSource(pattern, options) {
         .map(eachRelative);
 
       function eachRelative(value) {
-        return path.relative(outputPath, value);
+        return relative(outputPath, value, '.');
       }
     }
   }


### PR DESCRIPTION
glob-source returns paths that are not valid for require(). Fixed that by using some small npm module.

Before the content of output file was something like this:
`requre('api/aa/bb/cc.js');`

After:
`require('./api/aa/bb/cc.js');`
